### PR TITLE
Use empty `RawExtension` if `values` == nil

### DIFF
--- a/internal/controller/patcher.go
+++ b/internal/controller/patcher.go
@@ -71,8 +71,14 @@ func (p *Patcher) Build() ([]byte, error) {
 		}
 	}
 
+	// Use an empty runtime.RawExtension if nil
+	original := p.original
+	if original == nil {
+		original = &runtime.RawExtension{Raw: []byte("{}")}
+	}
+
 	// Now merge into the original runtime.RawExtension
-	m, err := compile(p.original)
+	m, err := compile(original)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`values` is nil if it's now provided in a `Feature`. Therefor the `Patcher` cannot successfully merge the nil `values` with overrides defined in any `FeatureOverride`.

Fixes #9 